### PR TITLE
Fix/plugin providing needed resolvers

### DIFF
--- a/plugin/src/main/scala/ProtoGenPlugin.scala
+++ b/plugin/src/main/scala/ProtoGenPlugin.scala
@@ -40,6 +40,14 @@ object ProtoGenPlugin extends AutoPlugin {
 
   import autoImport._
 
+  lazy val thisBuildSettings: Seq[Def.Setting[_]] = Seq(
+    resolvers ++= Seq(
+      Resolver.sonatypeRepo("snapshots"),
+      Resolver.sonatypeRepo("releases"),
+      Resolver.bintrayRepo("beyondthelines", "maven")
+    )
+  )
+
   lazy val defaultSettings: Seq[Def.Setting[_]] = Seq(
     protoGenSourceDir := baseDirectory.value / "src" / "main" / "scala",
     protoGenTargetDir := baseDirectory.value / "src" / "main" / "proto"
@@ -62,5 +70,5 @@ object ProtoGenPlugin extends AutoPlugin {
   )
 
   override def projectSettings: Seq[Def.Setting[_]] =
-    defaultSettings ++ protoGenTaskSettings
+    thisBuildSettings ++ defaultSettings ++ protoGenTaskSettings
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.8-SNAPSHOT"
+version in ThisBuild := "0.0.8"


### PR DESCRIPTION
This PR prevents applications using the plugin to have to specify the resolver because of the `pbdirect` transitive dependency.