### PR TITLE
Downgrade to cats 0.9.0 for sbt plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val core = project
   .settings(
     libraryDependencies ++= Seq(
       %%("frees-rpc-common", "0.1.1"),
-      %%("cats-core"),
+      %%("cats-core", "0.9.0"),
       %%("scalameta-contrib", "1.8.0"),
       %%("simulacrum")
     )

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.12-SNAPSHOT"
+version in ThisBuild := "0.0.12"


### PR DESCRIPTION
This is a "temporary fix" for https://github.com/frees-io/sbt-freestyle-protogen/issues/12 while other options are being explored.

There is a large consequence that `%%("frees-rpc-common")` **cannot** depend on cats 1.0. https://github.com/frees-io/freestyle-rpc/blob/v0.1.1/build.sbt#L26
Also, other dependencies for the plugin cannot depend on cats 1.0.

`sbt-freestyle` -> `sbt-org-policies` currently require cats 0.9.0.

Writing here for history:
`sbt-org-policies` requires `github4s`. `github4s` requires `circe`
`circe/circe`(with cats 1.0) requires `jawn-parser` 0.11.0
`sbt/sbt` 0.13 requires `jawn-parser` 0.6.0
`sbt/sbt` 1.0 requires `jawn-parser` 0.10.4

There is a binary incompatibility in between `jawn-parser` 0.10.4 and 0.11.0.

I have created PRs to bump `jawn-parser` for both sbt versions. There is a strong chance they will not be accepted, because it might break `sbt/sbt` binary compatibility.

