### PR TITLE
Updated deprecation warning and legacy usage in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-### Note: this project has been integrated into the [frees-rpc](https://github.com/frees-io/freestyle-rpc) codebase as `sbt-frees-rpc-idlgen`
-
 [comment]: # (Start Badges)
 
 [![Build Status](https://travis-ci.org/frees-io/sbt-freestyle-protogen.svg?branch=master)](https://travis-ci.org/frees-io/sbt-freestyle-protogen) [![codecov.io](http://codecov.io/github/frees-io/sbt-freestyle-protogen/coverage.svg?branch=master)](http://codecov.io/github/frees-io/sbt-freestyle-protogen?branch=master) [![Latest version](https://img.shields.io/badge/sbt--freestyle--protogen-0.0.14-green.svg)](https://index.scala-lang.org/frees-io/sbt-freestyle-protogen) [![License](https://img.shields.io/badge/license-Apache%202-blue.svg)](https://raw.githubusercontent.com/frees-io/sbt-freestyle-protogen/master/LICENSE) [![Join the chat at https://gitter.im/47deg/freestyle](https://badges.gitter.im/47deg/freestyle.svg)](https://gitter.im/47deg/freestyle?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![GitHub Issues](https://img.shields.io/github/issues/frees-io/sbt-freestyle-protogen.svg)](https://github.com/frees-io/sbt-freestyle-protogen/issues)
@@ -8,11 +6,13 @@
 
 # sbt-frees-protogen
 
+:warning: **Note: this project is deprecated and has been integrated into the [frees-rpc](https://github.com/frees-io/freestyle-rpc) codebase as `sbt-frees-rpc-idlgen` starting with version 0.12.0.**
+
 Sbt plugin to generate .proto files from freestyle-rpc service definitions.
 
 It depends on [frees-rpc](https://github.com/frees-io/freestyle-rpc).
 
-## Installation
+## Legacy Installation
 
 Add the following line to `project/plugins.sbt`:
 
@@ -25,9 +25,13 @@ addSbtPlugin("io.frees" % "sbt-frees-protogen" % "0.0.14")
 
 [comment]: # (End Replace)
 
-## Demo
+## Legacy Usage
 
-See [freestyle-rpc-examples repo](https://github.com/frees-io/freestyle-rpc-examples).
+Running
+```scala
+sbt protoGen
+```
+will generate `.proto` files from `src/main/scala` into `src/main/proto/`. These directories can be changed using the `protoGenSourceDir` and `protoGenTargetDir` settings.
 
 [comment]: # (Start Copyright)
 # Copyright


### PR DESCRIPTION
Also replaced Demo section with legacy usage example since the `freestyle-rpc-examples` repo isn't currently versioned and its content will be superseded by https://github.com/frees-io/freestyle-rpc-examples/pull/11.